### PR TITLE
Use plugin logger for logging

### DIFF
--- a/src/main/java/spoilagesystem/FoodSpoilage.java
+++ b/src/main/java/spoilagesystem/FoodSpoilage.java
@@ -21,6 +21,8 @@ import spoilagesystem.timestamp.LocalTimeStampService;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import static java.util.logging.Level.FINE;
+
 /**
  * @author Daniel McCoy Stephenson
  */
@@ -35,6 +37,9 @@ public final class FoodSpoilage extends PonderBukkitPlugin {
      */
     @Override
     public void onEnable() {
+        if (getConfig().getBoolean("debug", false)) {
+            getLogger().setLevel(FINE);
+        }
         commandService = new CommandService(getPonder());
         configService = new LocalConfigService(this);
         timeStampService = new LocalTimeStampService(this, configService);
@@ -62,14 +67,6 @@ public final class FoodSpoilage extends PonderBukkitPlugin {
         return commandService.interpretAndExecuteCommand(sender, label, args);
     }
 
-        /**
-     * Checks if debug is enabled.
-     * @return Whether debug is enabled.
-     */
-    public boolean isDebugEnabled() {
-        return getConfig().getBoolean("debug");
-    }
-
     private void handlebStatsIntegration() {
         int pluginId = 8992;
         new Metrics(this, pluginId);
@@ -84,9 +81,9 @@ public final class FoodSpoilage extends PonderBukkitPlugin {
                 new BlockCookEventHandler(configService, timeStampService),
                 new CraftItemEventHandler(configService, timeStampService, spoiledFoodFactory),
                 new FurnaceSmeltEventHandler(configService, timeStampService),
-                new InventoryDragEventHandler(timeStampService, spoiledFoodFactory),
+                new InventoryDragEventHandler(this, timeStampService, spoiledFoodFactory),
                 new ItemSpawnEventHandler(configService, timeStampService),
-                new PlayerInteractEventHandler(timeStampService, spoiledFoodFactory)
+                new PlayerInteractEventHandler(this, timeStampService, spoiledFoodFactory)
         ));
         eventHandlerRegistry.registerEventHandlers(listeners, this);
     }

--- a/src/main/java/spoilagesystem/commands/ReloadCommand.java
+++ b/src/main/java/spoilagesystem/commands/ReloadCommand.java
@@ -40,7 +40,7 @@ public final class ReloadCommand extends AbstractPluginCommand {
         }
         else {
             plugin.reloadConfig();
-            System.out.println(configService.getValuesLoadedText());
+            plugin.getLogger().fine(configService.getValuesLoadedText());
             return true;
         }
     }

--- a/src/main/java/spoilagesystem/config/LocalConfigService.java
+++ b/src/main/java/spoilagesystem/config/LocalConfigService.java
@@ -26,10 +26,6 @@ public final class LocalConfigService {
         plugin.saveDefaultConfig();
     }
 
-    /**
-     * Use this to see the spoil-time caching in real-time (for testing purposes only).
-     */
-    private static final boolean debug = false;
     private final Random random;
 
     /**
@@ -43,9 +39,7 @@ public final class LocalConfigService {
         String durationString = plugin.getConfig().getString("spoil-time." + type.toString(), plugin.getConfig().getString("default"));
         if (durationString == null) return Duration.ZERO;
         Duration time = Duration.parse(durationString); // Get the time from the config.
-        if (debug) {
-            System.out.println("Time from configuration for " + type.name() + ":\t" + time);
-        }
+        plugin.getLogger().fine("Time from configuration for " + type.name() + ":\t" + time);
         return time; // Return the key.
     }
 

--- a/src/main/java/spoilagesystem/eventhandlers/InventoryDragEventHandler.java
+++ b/src/main/java/spoilagesystem/eventhandlers/InventoryDragEventHandler.java
@@ -5,6 +5,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.ItemStack;
 
+import spoilagesystem.FoodSpoilage;
 import spoilagesystem.factories.SpoiledFoodFactory;
 import spoilagesystem.timestamp.LocalTimeStampService;
 
@@ -13,11 +14,12 @@ import spoilagesystem.timestamp.LocalTimeStampService;
  */
 public final class InventoryDragEventHandler implements Listener {
 
+    private final FoodSpoilage plugin;
     private final LocalTimeStampService timeStampService;
     private final SpoiledFoodFactory spoiledFoodFactory;
-    private boolean debug = false;
 
-    public InventoryDragEventHandler(LocalTimeStampService timeStampService, SpoiledFoodFactory spoiledFoodFactory) {
+    public InventoryDragEventHandler(FoodSpoilage plugin, LocalTimeStampService timeStampService, SpoiledFoodFactory spoiledFoodFactory) {
+        this.plugin = plugin;
         this.timeStampService = timeStampService;
         this.spoiledFoodFactory = spoiledFoodFactory;
     }
@@ -31,18 +33,18 @@ public final class InventoryDragEventHandler implements Listener {
             // if time stamped
             if (timeStampService.timeStampAssigned(item)) {
 
-                if (debug) { System.out.println("Item has timestamp!"); }
+                plugin.getLogger().fine("Item has timestamp!");
 
                 // if time stamp has been reached
                 if (timeStampService.timeReached(item)) {
 
-                    if (debug) { System.out.println("Time has been reached!"); }
+                    plugin.getLogger().fine("Time has been reached!");
 
                     // turn it into rotten flesh
                     event.setCursor(spoiledFoodFactory.createSpoiledFood(item));
 
                 } else {
-                    if (debug) { System.out.println("Time has not been reached!"); }
+                    plugin.getLogger().fine("Time has not been reached!");
                 }
             }
         }

--- a/src/main/java/spoilagesystem/eventhandlers/PlayerInteractEventHandler.java
+++ b/src/main/java/spoilagesystem/eventhandlers/PlayerInteractEventHandler.java
@@ -6,6 +6,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
+import spoilagesystem.FoodSpoilage;
 import spoilagesystem.factories.SpoiledFoodFactory;
 import spoilagesystem.timestamp.LocalTimeStampService;
 
@@ -14,11 +15,12 @@ import spoilagesystem.timestamp.LocalTimeStampService;
  */
 public final class PlayerInteractEventHandler implements Listener {
 
+    private final FoodSpoilage plugin;
     private final LocalTimeStampService timeStampService;
     private final SpoiledFoodFactory spoiledFoodFactory;
-    private boolean debug = false;
 
-    public PlayerInteractEventHandler(LocalTimeStampService timeStampService, SpoiledFoodFactory spoiledFoodFactory) {
+    public PlayerInteractEventHandler(FoodSpoilage plugin, LocalTimeStampService timeStampService, SpoiledFoodFactory spoiledFoodFactory) {
+        this.plugin = plugin;
         this.timeStampService = timeStampService;
         this.spoiledFoodFactory = spoiledFoodFactory;
     }
@@ -32,7 +34,7 @@ public final class PlayerInteractEventHandler implements Listener {
             // if time stamped
             if (timeStampService.timeStampAssigned(item)) {
 
-                if (debug) { System.out.println("Item has timestamp!"); }
+                plugin.getLogger().fine("Item has timestamp!");
 
                 EquipmentSlot hand = event.getHand();
                 if (hand != null) {
@@ -51,11 +53,11 @@ public final class PlayerInteractEventHandler implements Listener {
                                 event.getPlayer().getInventory().setItemInOffHand(spoiledFood);
                                 break;
                             default:
-                                if (debug) { System.out.println("Unknown Hand" + hand); }
+                                plugin.getLogger().fine("Unknown Hand " + hand);
                         }
                         event.setCancelled(true);
                     } else {
-                        if (debug) { System.out.println("Time has not been reached!"); }
+                        plugin.getLogger().fine("Time has not been reached!");
                     }
                 }
                 else {

--- a/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
+++ b/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
@@ -16,11 +16,13 @@ import java.util.Optional;
  */
 public final class LocalTimeStampService {
 
+    private final FoodSpoilage plugin;
     private final LocalConfigService configService;
 
     private final DateTimeFormatter dateFormatter;
 
     public LocalTimeStampService(FoodSpoilage plugin, LocalConfigService configService) {
+        this.plugin = plugin;
         this.configService = configService;
 
         dateFormatter = DateTimeFormatter.ofPattern(plugin.getConfig().getString("expiry-date-format", "MM/DD/yyyy"));
@@ -54,7 +56,7 @@ public final class LocalTimeStampService {
                 List<String> lore = meta.getLore();
 
                 if (lore != null) {
-                    // System.out.println("Debug] Time stamp is already assigned to this item!");
+                    plugin.getLogger().fine("Timestamp is already assigned to this item!");
                     List<String> expiryDateText = configService.getExpiryDateText();
                     if (lore.size() != expiryDateText.size()) return false;
                     for (int i = 0; i < expiryDateText.size(); i++) {
@@ -79,7 +81,7 @@ public final class LocalTimeStampService {
             }
         }
 
-        // System.out.println("[Debug] Time stamp is not yet applied to this item!");
+        plugin.getLogger().fine("Time stamp is not yet applied to this item!");
         return false;
     }
 


### PR DESCRIPTION
This PR moves debug log messages to the logger.
The plugin's log level is set to fine when debug is set to true for easy debugging.
The plugin's logger automatically marks messages with the plugin's tag and allows far more fine-grained control than println calls.