### PR TITLE
Refactor commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.Preponderous-Software:ponder:1.0'
+    implementation 'com.github.Preponderous-Software:ponder:1.1'
     implementation 'org.spigotmc:spigot-api:1.14.1-R0.1-SNAPSHOT'
     implementation 'org.bstats:bstats-bukkit:3.0.0'
 }

--- a/src/main/java/spoilagesystem/commands/DefaultCommand.java
+++ b/src/main/java/spoilagesystem/commands/DefaultCommand.java
@@ -1,35 +1,37 @@
 package spoilagesystem.commands;
 
-import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+import org.jetbrains.annotations.NotNull;
 import spoilagesystem.FoodSpoilage;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.bukkit.ChatColor.AQUA;
+import static org.bukkit.ChatColor.RED;
 
 /**
  * @author Daniel McCoy Stephenson
  */
-public final class DefaultCommand extends AbstractPluginCommand {
+public final class DefaultCommand implements CommandExecutor {
 
     private final FoodSpoilage plugin;
 
     public DefaultCommand(FoodSpoilage plugin) {
-        super(new ArrayList<>(List.of("default")), new ArrayList<>(List.of("fs.default")));
         this.plugin = plugin;
     }
 
     @Override
-    public boolean execute(CommandSender commandSender) {
-        commandSender.sendMessage(ChatColor.AQUA + plugin.getName() + " v" + plugin.getDescription().getVersion());
-        commandSender.sendMessage(ChatColor.AQUA + "Developed by: Daniel McCoy Stephenson");
-        commandSender.sendMessage(ChatColor.AQUA + "Wiki: https://github.com/Dans-Plugins/FoodSpoilage/wiki");
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!sender.hasPermission("fs.default")) {
+            sender.sendMessage(RED + "In order to use this command, you need one of the following permission: 'fs.default'");
+            return true;
+        }
+        sender.sendMessage(new String[] {
+                AQUA + plugin.getName() + " v" + plugin.getDescription().getVersion(),
+                AQUA + "Developed by: Daniel McCoy Stephenson",
+                AQUA + "Wiki: https://github.com/Dans-Plugins/FoodSpoilage/wiki"
+        });
         return true;
     }
 
-    @Override
-    public boolean execute(CommandSender commandSender, String[] strings) {
-        return execute(commandSender);
-    }
 }

--- a/src/main/java/spoilagesystem/commands/HelpCommand.java
+++ b/src/main/java/spoilagesystem/commands/HelpCommand.java
@@ -1,32 +1,30 @@
 package spoilagesystem.commands;
 
-import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.bukkit.ChatColor.AQUA;
+import static org.bukkit.ChatColor.RED;
 
 /**
  * @author Daniel McCoy Stephenson
  */
-public final class HelpCommand extends AbstractPluginCommand {
-
-    public HelpCommand() {
-        super(new ArrayList<>(List.of("help")), new ArrayList<>(List.of("fs.help")));
-    }
+public final class HelpCommand implements CommandExecutor {
 
     @Override
-    public boolean execute(CommandSender commandSender) {
-        commandSender.sendMessage(ChatColor.AQUA + "=== FoodSpoilage Commands ===");
-        commandSender.sendMessage(ChatColor.AQUA + "/fs help - View a list of helpful commands.");
-        commandSender.sendMessage(ChatColor.AQUA + "/fs timeleft - View how much time is left before an item expires.");
-        commandSender.sendMessage(ChatColor.AQUA + "/fs reload - Reload the plugin's configuration/save files.");
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, @NotNull String[] args) {
+        if (!sender.hasPermission("fs.help")) {
+            sender.sendMessage(RED + "In order to use this command, you need one of the following permission: 'fs.help'");
+            return true;
+        }
+        sender.sendMessage(new String[] {
+                AQUA + "=== FoodSpoilage Commands ===",
+                AQUA + "/fs help - View a list of helpful commands.",
+                AQUA + "/fs timeleft - View how much time is left before an item expires.",
+                AQUA + "/fs reload - Reload the plugin's configuration/save files."
+        });
         return true;
-    }
-
-    @Override
-    public boolean execute(CommandSender commandSender, String[] strings) {
-        return execute(commandSender);
     }
 }

--- a/src/main/java/spoilagesystem/commands/ReloadCommand.java
+++ b/src/main/java/spoilagesystem/commands/ReloadCommand.java
@@ -1,52 +1,36 @@
 package spoilagesystem.commands;
 
-import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+import org.jetbrains.annotations.NotNull;
 import spoilagesystem.FoodSpoilage;
 import spoilagesystem.config.LocalConfigService;
-import spoilagesystem.timestamp.LocalTimeStampService;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.bukkit.ChatColor.GREEN;
+import static org.bukkit.ChatColor.RED;
 
 /**
  * @author Daniel McCoy Stephenson
  */
-public final class ReloadCommand extends AbstractPluginCommand {
+public final class ReloadCommand implements CommandExecutor {
 
     private final FoodSpoilage plugin;
     private final LocalConfigService configService;
 
-    public ReloadCommand(FoodSpoilage plugin, LocalConfigService configService, LocalTimeStampService timeStampService) {
-        super(new ArrayList<>(List.of("reload")), new ArrayList<>(List.of("fs.reload")));
+    public ReloadCommand(FoodSpoilage plugin, LocalConfigService configService) {
         this.plugin = plugin;
         this.configService = configService;
     }
 
     @Override
-    public boolean execute(CommandSender sender) {
-        if (sender instanceof Player player) {
-            if (player.hasPermission("fs.reload") || player.hasPermission("fs.admin")) {
-                plugin.reloadConfig();
-                player.sendMessage(ChatColor.GREEN + configService.getValuesLoadedText());
-                return true;
-            }
-            else {
-                player.sendMessage(ChatColor.RED + configService.getNoPermsReloadText());
-                return false;
-            }
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, @NotNull String[] args) {
+        if (!sender.hasPermission("fs.reload") && !sender.hasPermission("fs.admin")) {
+            sender.sendMessage(RED + configService.getNoPermsReloadText());
+            return false;
         }
-        else {
-            plugin.reloadConfig();
-            plugin.getLogger().fine(configService.getValuesLoadedText());
-            return true;
-        }
-    }
-
-    @Override
-    public boolean execute(CommandSender commandSender, String[] strings) {
-        return execute(commandSender);
+        plugin.reloadConfig();
+        sender.sendMessage(GREEN + configService.getValuesLoadedText());
+        return true;
     }
 }

--- a/src/main/java/spoilagesystem/commands/TimeLeftCommand.java
+++ b/src/main/java/spoilagesystem/commands/TimeLeftCommand.java
@@ -1,31 +1,35 @@
 package spoilagesystem.commands;
 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+import org.jetbrains.annotations.NotNull;
 import spoilagesystem.config.LocalConfigService;
 import spoilagesystem.timestamp.LocalTimeStampService;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.bukkit.ChatColor.RED;
 
 /**
  * @author Daniel McCoy Stephenson
  */
-public final class TimeLeftCommand extends AbstractPluginCommand {
+public final class TimeLeftCommand implements CommandExecutor {
 
     private final LocalConfigService configService;
     private final LocalTimeStampService timeStampService;
 
     public TimeLeftCommand(LocalConfigService configService, LocalTimeStampService timeStampService) {
-        super(new ArrayList<>(List.of("timeleft")), new ArrayList<>(List.of("fs.timeleft")));
         this.configService = configService;
         this.timeStampService = timeStampService;
     }
 
     @Override
-    public boolean execute(CommandSender sender) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, @NotNull String[] args) {
+        if (!sender.hasPermission("fs.timeleft")) {
+            sender.sendMessage(RED + "In order to use this command, you need one of the following permission: 'fs.timeleft'");
+            return true;
+        }
         if (!(sender instanceof Player player)) {
             return false;
         }
@@ -39,10 +43,5 @@ public final class TimeLeftCommand extends AbstractPluginCommand {
         }
         player.sendMessage(timeLeft);
         return true;
-    }
-
-    @Override
-    public boolean execute(CommandSender commandSender, String[] strings) {
-        return execute(commandSender);
     }
 }

--- a/src/main/java/spoilagesystem/config/LocalConfigService.java
+++ b/src/main/java/spoilagesystem/config/LocalConfigService.java
@@ -85,34 +85,38 @@ public final class LocalConfigService {
     }
 
     public String getValuesLoadedText() {
-        return plugin.getConfig().getString("text.values-loaded");
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.values-loaded"));
     }
 
     public String getNoPermsReloadText() {
-        return plugin.getConfig().getString("text.no-permission-reload");
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.no-permission-reload"));
     }
 
     public String getSpoiledFoodName() {
-        return plugin.getConfig().getString("text.spoiled-food-name");
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.spoiled-food-name"));
     }
 
     public String getSpoiledFoodLore() {
-        return plugin.getConfig().getString("text.spoiled-food-lore");
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.spoiled-food-lore"));
     }
 
     public String getNeverSpoilText() {
-        return plugin.getConfig().getString("text.never-spoil");
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.never-spoil"));
     }
 
     public String getTimeLeftText() {
-        return plugin.getConfig().getString("text.time-left");
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.time-left"));
     }
 
     public String getLessThanAnHour() {
-        return plugin.getConfig().getString("text.less-than-an-hour");
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.less-than-an-hour"));
     }
 
     public String getLessThanADay() {
-        return plugin.getConfig().getString("text.less-than-a-day");
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.less-than-a-day"));
+    }
+
+    public String getNoTimeLeftText() {
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("text.no-time-left"));
     }
 }

--- a/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
+++ b/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
@@ -138,9 +138,15 @@ public final class LocalTimeStampService {
         int days = hours / 24;
 
         if (days == 0) {
-            return configService.getLessThanADay();
-        } else {
+            if (hours == 0) {
+                return configService.getLessThanAnHour();
+            } else {
+                return configService.getLessThanADay();
+            }
+        } else if (days > 0) {
             return configService.getTimeLeftText().replace("${time}", days + " days");
+        } else {
+            return configService.getNoTimeLeftText();
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,7 @@ text:
   time-left: 'This item will expire in ${time}.'
   less-than-an-hour: 'This item will expire in less than an hour.'
   less-than-a-day: 'This item will expire in less than a day.'
+  no-time-left: 'This item has expired.'
 expiry-date-format: 'MM/dd/yyyy'
 spoil-time:
   default: PT24H

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,9 +7,17 @@ website: 'https://www.spigotmc.org/resources/food-spoilage.81507/'
 
 commands:
   foodspoilage:
-  fs:
-
+    aliases: [fs]
+    description: |
+      Food spoilage base command
+      /foodspoilage - displays plugin information
+      /foodspoilage help - shows FoodSpoilage commands
+      /foodspoilage timeleft - displays the amount of time until the item in your hand expires
+      /foodspoilage reload - reloads the config
+    usage: /<command> [help|timeleft|reload]
 permissions:
+  fs.default:
+    default: true
   fs.help:
     default: true
   fs.timeleft:


### PR DESCRIPTION
This PR moves commands away from the Ponder commands to a purer Bukkit approach.

There's also some unneeded logic removed around console command senders for the reload command.

While Ponder handles permissions checks in a unified way for subcommands, I don't believe this is significant - permissions checks tend to be very few lines of code and have a clean, understandable API.

Ponder also provides a couple of other APIs - namely, two separate execute overloads and subcommand delegation.
I think there's perhaps room here for a better delegating command with subcommands in Ponder, but I believe that should be implemented as a CommandExecutor rather than pushing that logic into the command service. I don't think the command service adds very much, and the useful features it does provide (such as finding quoted arguments with spaces) aren't exposed to commands in a meaningful way. I think removing the command service and allowing plugins to use their own ArgumentParser where they need it is perhaps the way to go here.

The two separate execute overloads don't really add anything at all, and simply force plugins to write more lines of code to achieve more or less the same thing, so I've moved the existing commands into CommandExecutors and delegated to the subcommands from the base command executor.

Additionally, command handling is moved from overriding the plugin's onCommand to a command executor. Given that there is only one command that delegates to the subcommands, I've inlined it as a lambda, but if this logic were to grow, or more commands be added, I think separating out command executors for base commands into their own classes would be a good move.

There are a few tweaks around command text here too - the "less than an hour" message was not being shown at all, so I've added some additional logic to show that in the cases where there is less than an hour til the food expires.

Lastly, food that has _already_ expired was showing negative days (if consuming it had not been attempted and it was not already rotten flesh), so I added a new message to show that the food had already expired. This could potentially be expanded upon to replace the food with the expired food item then and there, if such behaviour is preferable.