### PR TITLE
Non-Edible Item Spawn Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 group = 'KingdomProgrammers'
 version = '3.0.0-SNAPSHOT'
 description = 'FoodSpoilage'
-java.sourceCompatibility = JavaVersion.VERSION_17
+java.sourceCompatibility = JavaVersion.VERSION_16
 
 import org.apache.tools.ant.filters.ReplaceTokens
 processResources {

--- a/src/main/java/spoilagesystem/listeners/ItemSpawnListener.java
+++ b/src/main/java/spoilagesystem/listeners/ItemSpawnListener.java
@@ -31,7 +31,7 @@ public final class ItemSpawnListener implements Listener {
         Duration time = configService.getTime(type);
 
         // if timestamp not already assigned
-        if (!time.equals(Duration.ZERO) && !timeStampService.timeStampAssigned(item)) {
+        if (!time.equals(Duration.ZERO) && !timeStampService.timeStampAssigned(item) && type.isEdible()) {
             event.getEntity().setItemStack(timeStampService.assignTimeStamp(item, time));
         }
     }


### PR DESCRIPTION
Ensured that only edible items were assigned timestamps upon spawning.