### PR TITLE
Fix shift clicking resulting in loss of items, closes #197

### DIFF
--- a/src/main/java/spoilagesystem/listeners/CraftItemListener.java
+++ b/src/main/java/spoilagesystem/listeners/CraftItemListener.java
@@ -53,7 +53,7 @@ public final class CraftItemListener implements Listener {
             int amountCrafted = getAmountCrafted(event);
             int spoilAmt = configService.determineSpoiledAmount(type, amountCrafted);
             List<ItemStack> results = new ArrayList<>();
-            int amount = item.getAmount();
+            int amount = amountCrafted;
             if (spoilAmt > 0) {
                 amount = amountCrafted - spoilAmt;
                 ItemStack spoiledFood = spoiledFoodFactory.createSpoiledFood(spoilAmt);
@@ -118,7 +118,7 @@ public final class CraftItemListener implements Listener {
             }
         }
         int spacesFree = 0;
-        for (int i = 0; i < Arrays.stream(event.getWhoClicked().getInventory().getStorageContents()).filter(Objects::nonNull).toList().size(); i++) {
+        for (int i = 0; i < Arrays.stream(event.getWhoClicked().getInventory().getStorageContents()).filter(Objects::isNull).toList().size(); i++) {
             spacesFree += event.getRecipe().getResult().getType().getMaxStackSize();
         }
         for (ItemStack item : event.getWhoClicked().getInventory().getStorageContents()) {


### PR DESCRIPTION
There were a couple of bugs where spoil chance was disabled resulting in the incorrect amount being calculated.

1. Total amount crafted was being set to the amount of the result of the recipe. this meant that no matter how many were being crafted, it would set back to 1 for recipes which produce one item per set of ingredients
2. When calculating free inventory space to place shift-clicked items into, empty spots were not being taken into account correctly. Therefore for an empty inventory sometimes shift clicking would become disabled.

This PR resolves these issues.