### PR TITLE
Made only edible items get assigned timestamps in the Block Cook Listener.

### DIFF
--- a/src/main/java/spoilagesystem/listeners/BlockCookListener.java
+++ b/src/main/java/spoilagesystem/listeners/BlockCookListener.java
@@ -18,6 +18,8 @@ public final class BlockCookListener implements Listener {
 
     @EventHandler
     public void onBlockCook(BlockCookEvent event) {
-        event.setResult(timeStampService.assignTimeStamp(event.getResult()));
+        if (event.getResult().getType().isEdible()) {
+            event.setResult(timeStampService.assignTimeStamp(event.getResult()));
+        }
     }
 }


### PR DESCRIPTION
Added an isEdible() check to the BlockCookListener class.