### PR TITLE
Add RPKit integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,15 @@ repositories {
     maven { url = uri('https://oss.sonatype.org/content/groups/public/') }
     maven { url = uri('https://jitpack.io') }
     maven { url = uri('https://repo.maven.apache.org/maven2/') }
+    maven { url = uri('https://repo.rpkit.com/repository/maven-releases/') }
 }
 
 dependencies {
     implementation 'com.github.Preponderous-Software:ponder:1.1'
     implementation 'org.spigotmc:spigot-api:1.14.1-R0.1-SNAPSHOT'
     implementation 'org.bstats:bstats-bukkit:3.0.0'
+    implementation 'com.rpkit:rpk-core-bukkit:2.3.0:all'
+    implementation 'com.rpkit:rpk-food-lib-bukkit:2.3.0:all'
 }
 
 group = 'KingdomProgrammers'

--- a/src/main/java/spoilagesystem/FoodSpoilage.java
+++ b/src/main/java/spoilagesystem/FoodSpoilage.java
@@ -2,6 +2,7 @@ package spoilagesystem;
 
 import org.bstats.bukkit.Metrics;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.Plugin;
 import preponderous.ponder.minecraft.bukkit.abs.PonderBukkitPlugin;
 import preponderous.ponder.minecraft.bukkit.tools.EventHandlerRegistry;
 import spoilagesystem.commands.DefaultCommand;
@@ -9,16 +10,16 @@ import spoilagesystem.commands.HelpCommand;
 import spoilagesystem.commands.ReloadCommand;
 import spoilagesystem.commands.TimeLeftCommand;
 import spoilagesystem.config.LocalConfigService;
-import spoilagesystem.listeners.*;
 import spoilagesystem.factories.SpoiledFoodFactory;
+import spoilagesystem.listeners.*;
+import spoilagesystem.rpkit.FoodSpoilageRpkitExpiryService;
 import spoilagesystem.timestamp.LocalTimeStampService;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.bukkit.ChatColor.RED;
-
 import static java.util.logging.Level.FINE;
+import static org.bukkit.ChatColor.RED;
 
 /**
  * @author Daniel McCoy Stephenson
@@ -43,11 +44,20 @@ public final class FoodSpoilage extends PonderBukkitPlugin {
         registerEventHandlers();
         initializeCommands();
         handlebStatsIntegration();
+        handleRpkitIntegration();
     }
 
     private void handlebStatsIntegration() {
         int pluginId = 8992;
         new Metrics(this, pluginId);
+    }
+
+    private void handleRpkitIntegration() {
+        Plugin rpkFoodLib = getServer().getPluginManager().getPlugin("rpk-food-lib-bukkit");
+        if (rpkFoodLib != null) {
+            getLogger().info("RPKit Food Lib found, enabling integration");
+            new FoodSpoilageRpkitExpiryService(this, timeStampService);
+        }
     }
 
     /**

--- a/src/main/java/spoilagesystem/rpkit/FoodSpoilageRpkitExpiryService.java
+++ b/src/main/java/spoilagesystem/rpkit/FoodSpoilageRpkitExpiryService.java
@@ -1,0 +1,52 @@
+package spoilagesystem.rpkit;
+
+import com.rpkit.core.service.Services;
+import com.rpkit.food.bukkit.expiry.RPKExpiryService;
+import org.bukkit.inventory.ItemStack;
+import spoilagesystem.FoodSpoilage;
+import spoilagesystem.timestamp.LocalTimeStampService;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+public class FoodSpoilageRpkitExpiryService implements RPKExpiryService {
+
+    private final FoodSpoilage plugin;
+    private final LocalTimeStampService timeStampService;
+
+    public FoodSpoilageRpkitExpiryService(FoodSpoilage plugin, LocalTimeStampService timeStampService) {
+        this.plugin = plugin;
+        this.timeStampService = timeStampService;
+        Services.INSTANCE.set(RPKExpiryService.class, this);
+    }
+
+    @Override
+    public FoodSpoilage getPlugin() {
+        return plugin;
+    }
+
+    @Override
+    public void setExpiry(ItemStack item, Duration duration) {
+        timeStampService.assignTimeStamp(item, duration);
+    }
+
+    @Override
+    public void setExpiry(ItemStack item, OffsetDateTime dateTime) {
+        timeStampService.assignTimeStamp(item, Duration.between(OffsetDateTime.now(), dateTime));
+    }
+
+    @Override
+    public void setExpiry(ItemStack itemStack) {
+        timeStampService.assignTimeStamp(itemStack);
+    }
+
+    @Override
+    public OffsetDateTime getExpiry(ItemStack item) {
+        return timeStampService.getTimeStamp(item);
+    }
+
+    @Override
+    public boolean isExpired(ItemStack item) {
+        return timeStampService.timeReached(item);
+    }
+}

--- a/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
+++ b/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
@@ -118,7 +118,7 @@ public final class LocalTimeStampService {
         return false;
     }
 
-    private OffsetDateTime getTimeStamp(ItemStack item) {
+    public OffsetDateTime getTimeStamp(ItemStack item) {
         if (timeStampAssigned(item)) {
             ItemMeta meta = item.getItemMeta();
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,8 @@ authors: [DanTheTechMan, Undead_Zeratul, Caibinus, Callum, alyphen]
 main: spoilagesystem.FoodSpoilage
 api-version: 1.13
 website: 'https://www.spigotmc.org/resources/food-spoilage.81507/'
-
+softdepend:
+- rpk-food-lib-bukkit
 commands:
   foodspoilage:
     aliases: [fs]


### PR DESCRIPTION
This PR adds optional integration with RPKit.
If rpk-food-lib-bukkit is detected, it will register a service with RPKit that allows plugins that use rpk-food-lib to seamlessly integrate with FoodSpoilage.
This allows, for example, rpk-trade-bukkit to set expiry with FoodSpoilage: https://github.com/RP-Kit/RPKit/blob/main/bukkit/rpk-trade-bukkit/src/main/kotlin/com/rpkit/trade/bukkit/listener/PlayerInteractListener.kt#L107