### PR TITLE
Parse with try/catch block

### DIFF
--- a/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
+++ b/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
@@ -133,15 +133,19 @@ public final class LocalTimeStampService {
 
     @Nullable
     private OffsetDateTime parseExpiryFromPersistentData(ItemMeta meta) {
-        String expiryString = meta.getPersistentDataContainer().get(expiryKey, STRING);
-        if (expiryString != null) {
-            try {
-                return OffsetDateTime.parse(expiryString, ISO_OFFSET_DATE);
-            } catch (DateTimeParseException exception) {
-                plugin.getLogger().log(SEVERE, "Failed to parse expiry from persistent data container", exception);
+        try {
+            String expiryString = meta.getPersistentDataContainer().get(expiryKey, STRING);
+            if (expiryString != null) {
+                try {
+                    return OffsetDateTime.parse(expiryString, ISO_OFFSET_DATE);
+                } catch (DateTimeParseException exception) {
+                    plugin.getLogger().log(SEVERE, "Failed to parse expiry from persistent data container", exception);
+                }
             }
+            return null;
+        } catch(Exception e) {
+            return null;
         }
-        return null;
     }
 
     @Nullable

--- a/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
+++ b/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
@@ -133,19 +133,16 @@ public final class LocalTimeStampService {
 
     @Nullable
     private OffsetDateTime parseExpiryFromPersistentData(ItemMeta meta) {
-        try {
-            String expiryString = meta.getPersistentDataContainer().get(expiryKey, STRING);
-            if (expiryString != null) {
-                try {
-                    return OffsetDateTime.parse(expiryString, ISO_OFFSET_DATE);
-                } catch (DateTimeParseException exception) {
-                    plugin.getLogger().log(SEVERE, "Failed to parse expiry from persistent data container", exception);
-                }
+        String expiryString = meta.getPersistentDataContainer().get(expiryKey, STRING);
+        if (expiryString != null) {
+            try {
+                return OffsetDateTime.parse(expiryString, ISO_OFFSET_DATE);
+            } catch (DateTimeParseException exception) {
+                // plugin.getLogger().log(SEVERE, "Failed to parse expiry from persistent data container", exception);
+                // ignored to avoid spamming console on servers that upgraded from pre-3.0.0
             }
-            return null;
-        } catch(Exception e) {
-            return null;
         }
+        return null;
     }
 
     @Nullable


### PR DESCRIPTION
Added a try/catch block to the parsing method in LocalTimeStampService. This should hopefully make some errors that occur from upgrading happen silently.